### PR TITLE
Add filter-seqids subcommand

### DIFF
--- a/src/heyfastqlib/command.py
+++ b/src/heyfastqlib/command.py
@@ -199,11 +199,13 @@ def heyfastq_main(argv=None):
         help="Filter reads by sequence id",
     )
     filter_seq_ids_parser.add_argument(
-        "idsfile", type=argparse.FileType("r"),
-        help="File containing sequence ids, one per line"
+        "idsfile",
+        type=argparse.FileType("r"),
+        help="File containing sequence ids, one per line",
     )
     filter_seq_ids_parser.add_argument(
-        "--keep-ids", action="store_true",
+        "--keep-ids",
+        action="store_true",
         help="Keep, rather than remove ids in list",
     )
     filter_seq_ids_parser.set_defaults(func=filter_seq_ids_subcommand)

--- a/src/heyfastqlib/io.py
+++ b/src/heyfastqlib/io.py
@@ -32,3 +32,12 @@ def write_fastq_paired(fs, paired_recs):
     for paired_rec in paired_recs:
         for f, read in zip(fs, paired_rec):
             f.write("@{0}\n{1}\n+\n{2}\n".format(read.desc, read.seq, read.qual))
+
+
+def parse_seq_ids(f):
+    for line in f:
+        line = line.strip()
+        if line.startswith("#") or (line == ""):
+            continue
+        seq_id = line.split()[0]
+        yield seq_id

--- a/src/heyfastqlib/read.py
+++ b/src/heyfastqlib/read.py
@@ -38,12 +38,12 @@ def length_ok(read, threshold=100, cmp=operator.ge):
     return cmp(length(read), threshold)
 
 
-def seq_id_ok(read, seq_ids, remove=False):
+def seq_id_ok(read, seq_ids, keep=False):
     id = seq_id(read)
-    if remove:
-        return id not in seq_ids
-    else:
+    if keep:
         return id in seq_ids
+    else:
+        return id not in seq_ids
 
 
 def trim_moving_average(read, k=4, threshold=15):

--- a/src/heyfastqlib/read.py
+++ b/src/heyfastqlib/read.py
@@ -12,6 +12,10 @@ class Read:
     qual: str
 
 
+def seq_id(read):
+    return read.desc.split()[0]
+
+
 def length(read):
     return len(read.seq)
 
@@ -32,6 +36,14 @@ def kscore_ok(read, k=4, min_kscore=0.55):
 
 def length_ok(read, threshold=100, cmp=operator.ge):
     return cmp(length(read), threshold)
+
+
+def seq_id_ok(read, seq_ids, remove=False):
+    id = seq_id(read)
+    if remove:
+        return id not in seq_ids
+    else:
+        return id in seq_ids
 
 
 def trim_moving_average(read, k=4, threshold=15):

--- a/src/heyfastqlib/test/test_command.py
+++ b/src/heyfastqlib/test/test_command.py
@@ -196,3 +196,37 @@ def test_filter_length_command(tmp_path):
         assert f.read() == "@a\nACGTACGTACGT\n+\n123456789012\n"
     with open(out2) as f:
         assert f.read() == "@a\nAGGTCGTCTAAC\n+\n123456789012\n"
+
+
+in1_seqids = """\
+@a
+CGTA
++
+1234
+@b
+GTCC
++
+5678
+"""
+
+
+def test_filter_seq_ids_command(tmp_path):
+    in1 = tmp_path / "input_1.fastq"
+    with open(in1, "w") as f:
+        f.write(in1_seqids)
+    ids_path = tmp_path / "ids.txt"
+    with open(ids_path, "w") as f:
+        f.write("a\n")
+    out1 = tmp_path / "output_1.fastq"
+    heyfastq_main(
+        [
+            "filter-seqids",
+            str(ids_path),
+            "--input",
+            str(in1),
+            "--output",
+            str(out1),
+        ]
+    )
+    with open(out1) as f:
+        assert f.read() == "@b\nGTCC\n+\n5678\n"

--- a/src/heyfastqlib/test/test_io.py
+++ b/src/heyfastqlib/test/test_io.py
@@ -54,3 +54,8 @@ def test_write_fastq_paired():
     write_fastq_paired((f1, f2), paired_recs)
     assert f1.contents == "@a\nCGT\n+\nBBC\n@b\nGTA\n+\nAAB\n"
     assert f2.contents == "@a\nACG\n+\nCCD\n@b\nTAC\n+\nEEF\n"
+
+
+def test_parse_seq_ids():
+    f = ["Id1\n", "\tId2|345 678  \n", "   ", "   # a comment", "  id3"]
+    assert list(parse_seq_ids(f)) == ["Id1", "Id2|345", "id3"]

--- a/src/heyfastqlib/test/test_read.py
+++ b/src/heyfastqlib/test/test_read.py
@@ -105,6 +105,6 @@ def test_trim_ends():
 
 def test_seq_id_ok():
     ids = ["cd", "b"]
-    assert seq_id_ok(Read("b", "GGC", "FFF"), ids)
-    assert not seq_id_ok(Read("a", "TCG", "FFF"), ids)
-    assert not seq_id_ok(Read("cd", "TCG", "!!!"), ids, remove=True)
+    assert not seq_id_ok(Read("b", "GGC", "FFF"), ids)
+    assert seq_id_ok(Read("a", "TCG", "FFF"), ids)
+    assert seq_id_ok(Read("cd", "TCG", "!!!"), ids, keep=True)

--- a/src/heyfastqlib/test/test_read.py
+++ b/src/heyfastqlib/test/test_read.py
@@ -7,6 +7,7 @@ from heyfastqlib.read import (
     length_ok,
     trim_moving_average,
     trim_ends,
+    seq_id_ok,
 )
 
 
@@ -100,3 +101,10 @@ def test_trim_ends():
     # q6   - -  +  +  + -  + - Trim 2:7
     assert trim_ends(a, 20, 20) == trim(a, 2, 5)
     assert trim_ends(a, 6, 6) == trim(a, 2, 7)
+
+
+def test_seq_id_ok():
+    ids = ["cd", "b"]
+    assert seq_id_ok(Read("b", "GGC", "FFF"), ids)
+    assert not seq_id_ok(Read("a", "TCG", "FFF"), ids)
+    assert not seq_id_ok(Read("cd", "TCG", "!!!"), ids, remove=True)


### PR DESCRIPTION
Added a new subcommand to filter by sequence id.

The heyfastq version of this subcommand _removes_ ids in the list by default, in contrast to the okfasta subcommand, which _keeps_ ids in the list by default. I think this is the more useful default behavior, and we should look to changing the interface on okfasta if we're to change anything.

Comments, blank lines, and leading whitespace are allowed in the ids file, though the allowance is not documented.
