### PR TITLE
Add Dockerfile for containerized usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Ignore Python cache and build artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+
+# Ignore Git metadata and CI configuration
+.git
+.gitignore
+.github/
+
+# Ignore test caches
+.pytest_cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim
+
+# Set up the working directory for the application
+WORKDIR /app
+
+# Copy project metadata first to leverage Docker layer caching
+COPY pyproject.toml README.md /app/
+
+# Copy the source code into the image
+COPY src /app/src
+
+# Install the package and its CLI entrypoint
+RUN pip install --no-cache-dir .
+
+# Default command prints usage instructions; override to run other subcommands
+ENTRYPOINT ["heyfastq"]
+CMD ["--help"]


### PR DESCRIPTION
## Summary
- add a Dockerfile that installs heyfastq into a Python 3.11 slim image and exposes the CLI
- add a .dockerignore to keep build context small and omit dev artifacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dab129b29c8323bc8b32d1c4fc7c1c