### PR TITLE
Refine subcommand pipelines

### DIFF
--- a/src/heyfastqlib/command.py
+++ b/src/heyfastqlib/command.py
@@ -1,7 +1,9 @@
 import argparse
 import operator
+from functools import partial
 import signal
 import sys
+from dataclasses import dataclass
 
 from . import __version__
 from .util import (
@@ -24,55 +26,120 @@ from .read import (
 from .argparse_types import GzipFileType, HFQFormatter
 
 
+@dataclass
+class ReadStats:
+    total_reads: int = 0
+    total_bases: int = 0
+
+    def observe(self, paired_read):
+        for read in paired_read:
+            self.total_reads += 1
+            self.total_bases += len(read.seq)
+
+    @property
+    def average_length(self):
+        if self.total_reads == 0:
+            return 0.0
+        return self.total_bases / self.total_reads
+
+
+def _iter_with_stats(paired_reads, stats):
+    for paired_read in paired_reads:
+        stats.observe(paired_read)
+        yield paired_read
+
+
+def _log_stats(label, stats):
+    print(
+        f"{label} reads: total={stats.total_reads}, average_length={stats.average_length:.2f}",
+        file=sys.stderr,
+    )
+
+
+def _run_paired_command(args, build_output):
+    input_stats = ReadStats()
+    output_stats = ReadStats()
+
+    reads = _iter_with_stats(parse_fastq_paired(args.input), input_stats)
+    out_reads = build_output(reads)
+    write_fastq_paired(args.output, _iter_with_stats(out_reads, output_stats))
+
+    _log_stats("Input", input_stats)
+    _log_stats("Output", output_stats)
+
+
 def subsample_subcommand(args):
-    reads = parse_fastq_paired(args.input)
-    out_reads = subsample(reads, args.n, args.seed)
-    write_fastq_paired(args.output, out_reads)
+    _run_paired_command(
+        args,
+        partial(subsample, n=args.n, seed=args.seed),
+    )
 
 
 def trim_fixed_subcommand(args):
-    reads = parse_fastq_paired(args.input)
-    out_reads = map_paired(reads, trim, end_idx=args.length)
-    write_fastq_paired(args.output, out_reads)
+    _run_paired_command(
+        args,
+        partial(map_paired, f=trim, end_idx=args.length),
+    )
 
 
 def trim_qual_subcommand(args):
-    reads = parse_fastq_paired(args.input)
-    trimmed_moving_average_reads = map_paired(
-        reads, trim_moving_average, k=args.window_width, threshold=args.window_threshold
+    _run_paired_command(
+        args,
+        partial(
+            _trim_quality_pipeline,
+            window_width=args.window_width,
+            window_threshold=args.window_threshold,
+            start_threshold=args.start_threshold,
+            end_threshold=args.end_threshold,
+            min_length=args.min_length,
+        ),
     )
-    trimmed_ends_reads = map_paired(
-        trimmed_moving_average_reads,
-        trim_ends,
-        threshold_start=args.start_threshold,
-        threshold_end=args.end_threshold,
-    )
-    filtered_reads = filter_paired(
-        trimmed_ends_reads, length_ok, threshold=args.min_length
-    )
-    write_fastq_paired(args.output, filtered_reads)
 
 
 def filter_length_subcommand(args):
-    reads = parse_fastq_paired(args.input)
     cmp = operator.lt if args.less else operator.ge
-    out_reads = filter_paired(reads, length_ok, threshold=args.length, cmp=cmp)
-    write_fastq_paired(args.output, out_reads)
+
+    _run_paired_command(
+        args,
+        partial(filter_paired, f=length_ok, threshold=args.length, cmp=cmp),
+    )
 
 
 def filter_kscore_subcommand(args):
-    reads = parse_fastq_paired(args.input)
-    out_reads = filter_paired(
-        reads, kscore_ok, k=args.kmer_size, min_kscore=args.min_kscore
+    _run_paired_command(
+        args,
+        partial(filter_paired, f=kscore_ok, k=args.kmer_size, min_kscore=args.min_kscore),
     )
-    write_fastq_paired(args.output, out_reads)
 
 
 def filter_seq_ids_subcommand(args):
     seq_ids = set(parse_seq_ids(args.idsfile))
-    reads = parse_fastq_paired(args.input)
-    out_reads = filter_paired(reads, seq_id_ok, seq_ids=seq_ids, keep=args.keep_ids)
-    write_fastq_paired(args.output, out_reads)
+
+    _run_paired_command(
+        args,
+        partial(filter_paired, f=seq_id_ok, seq_ids=seq_ids, keep=args.keep_ids),
+    )
+
+
+def _trim_quality_pipeline(
+    reads,
+    *,
+    window_width,
+    window_threshold,
+    start_threshold,
+    end_threshold,
+    min_length,
+):
+    trimmed_moving_average_reads = map_paired(
+        reads, trim_moving_average, k=window_width, threshold=window_threshold
+    )
+    trimmed_ends_reads = map_paired(
+        trimmed_moving_average_reads,
+        trim_ends,
+        threshold_start=start_threshold,
+        threshold_end=end_threshold,
+    )
+    return filter_paired(trimmed_ends_reads, length_ok, threshold=min_length)
 
 
 fastq_io_parser = argparse.ArgumentParser(add_help=False, formatter_class=HFQFormatter)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+import io
+
+import pytest
+
+from heyfastqlib.command import (
+    ReadStats,
+    _iter_with_stats,
+    _run_paired_command,
+)
+from heyfastqlib.paired_reads import map_paired
+from heyfastqlib.read import Read
+
+
+def _make_read(desc: str, seq: str) -> Read:
+    return Read(desc, seq, "I" * len(seq))
+
+
+def _make_fastq_text(reads):
+    return "".join(f"@{read.desc}\n{read.seq}\n+\n{read.qual}\n" for read in reads)
+
+
+def test_read_stats_observes_paired_reads():
+    stats = ReadStats()
+    paired_read = (
+        _make_read("r1/1", "AAAA"),
+        _make_read("r1/2", "AAA"),
+    )
+
+    stats.observe(paired_read)
+
+    assert stats.total_reads == 2
+    assert stats.total_bases == 7
+    assert pytest.approx(stats.average_length) == 3.5
+
+
+def test_iter_with_stats_passthroughs_reads():
+    stats = ReadStats()
+    pairs = [
+        (
+            _make_read("r1/1", "AAAA"),
+            _make_read("r1/2", "AAA"),
+        ),
+        (
+            _make_read("r2/1", "CC"),
+            _make_read("r2/2", "C"),
+        ),
+    ]
+
+    result = list(_iter_with_stats(iter(pairs), stats))
+
+    assert result == pairs
+    assert stats.total_reads == 4
+    assert stats.total_bases == 10
+    assert pytest.approx(stats.average_length) == 2.5
+
+
+def test_run_paired_command_logs_input_and_output_stats(capsys):
+    mate1_reads = [
+        _make_read("r1/1", "AAAA"),
+        _make_read("r2/1", "CCCCC"),
+    ]
+    mate2_reads = [
+        _make_read("r1/2", "GGG"),
+        _make_read("r2/2", "TTTTTT"),
+    ]
+
+    def shorten(read: Read) -> Read:
+        return Read(read.desc, read.seq[:-1], read.qual[:-1])
+
+    def transform(reads):
+        return map_paired(reads, shorten)
+
+    args = SimpleNamespace(
+        input=[
+            io.StringIO(_make_fastq_text(mate1_reads)),
+            io.StringIO(_make_fastq_text(mate2_reads)),
+        ],
+        output=[io.StringIO(), io.StringIO()],
+    )
+
+    _run_paired_command(args, transform)
+
+    stderr = capsys.readouterr().err.strip().splitlines()
+    assert stderr[0] == "Input reads: total=4, average_length=4.50"
+    assert stderr[1] == "Output reads: total=4, average_length=3.50"
+
+    output_reads = [
+        _make_fastq_text([Read(r.desc, r.seq[:-1], r.qual[:-1]) for r in mate1_reads]),
+        _make_fastq_text([Read(r.desc, r.seq[:-1], r.qual[:-1]) for r in mate2_reads]),
+    ]
+
+    assert args.output[0].getvalue() == output_reads[0]
+    assert args.output[1].getvalue() == output_reads[1]


### PR DESCRIPTION
## Summary
- adjust `_run_paired_command` to take a pipeline builder and reuse `functools.partial` when invoking it
- simplify each subcommand by directly passing its pipeline into the shared runner and extract a helper for trim-quality chaining

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dae3410b148323ab279fe828358255