### PR TITLE
Add CLI option to control gzip compression level

### DIFF
--- a/src/heyfastqlib/argparse_types.py
+++ b/src/heyfastqlib/argparse_types.py
@@ -1,6 +1,20 @@
 import gzip
 import sys
 import argparse
+from typing import Optional
+
+
+_gzip_output_compresslevel: Optional[int] = None
+
+
+def set_gzip_output_compresslevel(level: Optional[int]) -> None:
+    """Configure the compression level used for gzip outputs.
+
+    A value of ``None`` falls back to Python's default compression level.
+    """
+
+    global _gzip_output_compresslevel
+    _gzip_output_compresslevel = level
 
 
 class GzipFileType(object):
@@ -48,12 +62,18 @@ class GzipFileType(object):
                 gzipped = string.endswith(".gz")
 
             if gzipped:
+                gzip_kwargs = {}
+                if "w" in self._mode and _gzip_output_compresslevel is not None:
+                    gzip_kwargs["compresslevel"] = _gzip_output_compresslevel
+                if self._encoding is not None:
+                    gzip_kwargs["encoding"] = self._encoding
+                if self._errors is not None:
+                    gzip_kwargs["errors"] = self._errors
+
                 f = gzip.open(
                     string,
                     f"{self._mode}t",
-                    self._bufsize,
-                    self._encoding,
-                    self._errors,
+                    **gzip_kwargs,
                 )
             else:
                 f = open(

--- a/tests/test_argparse_types.py
+++ b/tests/test_argparse_types.py
@@ -1,0 +1,42 @@
+import io
+
+from heyfastqlib.argparse_types import (
+    GzipFileType,
+    set_gzip_output_compresslevel,
+)
+
+
+def test_gzip_file_type_respects_configured_compression_level(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_gzip_open(filename, mode, **kwargs):
+        captured["filename"] = filename
+        captured["mode"] = mode
+        captured["kwargs"] = kwargs
+        return io.StringIO()
+
+    monkeypatch.setattr("heyfastqlib.argparse_types.gzip.open", fake_gzip_open)
+
+    output_path = tmp_path / "reads.fastq.gz"
+    set_gzip_output_compresslevel(5)
+    handle = GzipFileType("w")(str(output_path))
+    handle.write("@r1\nACGT\n+\nIIII\n")
+
+    assert captured["filename"] == str(output_path)
+    assert captured["mode"] == "wt"
+    assert captured["kwargs"]["compresslevel"] == 5
+
+
+def test_gzip_file_type_uses_default_when_level_not_set(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_gzip_open(filename, mode, **kwargs):
+        captured["kwargs"] = kwargs
+        return io.StringIO()
+
+    monkeypatch.setattr("heyfastqlib.argparse_types.gzip.open", fake_gzip_open)
+
+    set_gzip_output_compresslevel(None)
+    GzipFileType("w")(str(tmp_path / "reads.fastq.gz"))
+
+    assert "compresslevel" not in captured["kwargs"]


### PR DESCRIPTION
## Summary
- add a shared `--gzip-level` option to configure compression for gzip outputs
- update the gzip file factory to honor the configured compression level
- add regression tests covering custom and default gzip compression level handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f0031406548323980f3edabf62b47e