### PR TITLE
Use filter_reads for subsampling

### DIFF
--- a/src/heyfastqlib/pipelines.py
+++ b/src/heyfastqlib/pipelines.py
@@ -1,9 +1,8 @@
 from itertools import islice
 from multiprocessing import Pool
-from typing import Callable, Iterable, Iterator, Optional
+from typing import Callable, Iterable, Iterator
 
 from .read import count_bases, R, ReadPipe
-from .util import subsample
 
 
 CounterDict = dict[str, int]
@@ -145,29 +144,3 @@ def map_reads(
                 yield r
 
 
-def subsample_reads(
-    rs: ReadPipe[R],
-    l: int,
-    n: int,
-    seed: Optional[int],
-    *,
-    counter: Optional[CounterDict] = None,
-) -> ReadPipe[R]:
-    """
-    Subsample is a weird one because it requires working with a full list of reads' indexes in memory
-    Doesn't really fit with the pipeline model
-    """
-    idxs = set(subsample(list(range(l)), n, seed))
-    for i, r in enumerate(rs):
-        bases = None
-        if counter is not None:
-            counter["input_reads"] += 1
-            bases = count_bases(r)
-            counter["input_bases"] += bases
-        if i in idxs:
-            if counter is not None:
-                if bases is None:
-                    bases = count_bases(r)
-                counter["output_reads"] += 1
-                counter["output_bases"] += bases
-            yield r


### PR DESCRIPTION
## Summary
- remove the dedicated subsample_reads pipeline
- call filter_reads with util.subsample to drive the subsample subcommand
- update pipeline tests to exercise subsampling through filter_reads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f8ff17db188323861bcc94906f2b9d